### PR TITLE
Adding a space

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,4 @@
 For all security related bugs, email security@ansible.com instead of using this issue tracker and you will receive a prompt response.
 
 For more information on the Ansible community's practices regarding responsible disclosure, see https://www.ansible.com/security
+


### PR DESCRIPTION
##### SUMMARY
To reproduce:

`echo Hello?`
Add some quotes """"" \\\\\"
;;;; "; 
New or Enhanced Feature
Breaking Change

run `docker-compose` with 1 control node and 1 execution node. Then

```
docker exec -it --user=0 tools_receptor_1 /bin/bash
```

While you're in there, modify this file:

```
vi /var/lib/awx/venv/awx/lib/python3.9/site-packages/ansible_runner/__main__.py
```

And look for the "worker_info" parsing. Now raise a custom exception there, to the net result of:

```
bash-5.1# ansible-runner worker --worker-info
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/bin/ansible-runner", line 8, in <module>
    sys.exit(main())
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/ansible_runner/__main__.py", line 742, in main
    raise Exception('alan!')
Exception: alan!
```

Okay, now go back to the control node (or UI) and run a health check.

```
from awx.main.tasks.receptor import worker_info
worker_info("receptor-1")
```

Expected result: I get "alan!" somewhere in there.

Actual result: 

```
{'errors': ['Receptor error from receptor-1, detail:\nexit status 1'],
 'transmit_timing': 0.08971476554870605,
 'run_timing': 1.002617597579956}
```

This fixes it, so that it gives

```
{'errors': ['Receptor error from receptor-1, detail:\nexit status 1\nstdout:\nTraceback (most recent call last):\n  File "/var/lib/awx/venv/awx/bin/ansible-runner", line 8, in <module>\n    sys.exit(main())\n  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/ansible_runner/__main__.py", line 742, in main\n    raise Exception(\'alan!\')\nException: alan!\n'],
 'transmit_timing': 0.08607053756713867,
 'run_timing': 1.00270676612854}
```

This still leaves things a little confusing and bloated, but I'd like to start out getting sufficient error details and then moving forward from there.

##### ISSUE TYPE


##### COMPONENT NAME
 - API

